### PR TITLE
added support for the Job DSL plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,15 @@ THE SOFTWARE.
     </developer>
   </developers>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>job-dsl</artifactId>
+      <version>1.41</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+
   <!-- get every artifact through maven.glassfish.org, which proxies all the artifacts that we need -->
   <repositories>
     <repository>

--- a/src/main/java/org/jvnet/hudson/plugins/nextbuildnumber/JobDslExtension.java
+++ b/src/main/java/org/jvnet/hudson/plugins/nextbuildnumber/JobDslExtension.java
@@ -1,0 +1,36 @@
+package org.jvnet.hudson.plugins.nextbuildnumber;
+
+import hudson.Extension;
+import hudson.model.Item;
+import hudson.model.Job;
+import javaposse.jobdsl.dsl.helpers.properties.PropertiesContext;
+import javaposse.jobdsl.plugin.ContextExtensionPoint;
+import javaposse.jobdsl.plugin.DslEnvironment;
+import javaposse.jobdsl.plugin.DslExtensionMethod;
+
+import java.io.IOException;
+
+@Extension(optional = true)
+public class JobDslExtension extends ContextExtensionPoint {
+  @DslExtensionMethod(context = PropertiesContext.class)
+  public Object nextBuildNumber(int number, DslEnvironment dslEnvironment) {
+    dslEnvironment.put("nextBuildNumber", number);
+    return null;
+  }
+
+  @Override
+  public void notifyItemCreated(Item item, DslEnvironment dslEnvironment) {
+    notifyItemUpdated(item, dslEnvironment);
+  }
+
+  @Override
+  public void notifyItemUpdated(Item item, DslEnvironment dslEnvironment) {
+    if (item instanceof Job && dslEnvironment.get("nextBuildNumber") instanceof Integer) {
+      try {
+        ((Job) item).updateNextBuildNumber((Integer) dslEnvironment.get("nextBuildNumber"));
+      } catch (IOException e) {
+        throw new RuntimeException("could not update build number for " + item.getFullName(), e);
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds Job DSL support for the Next Build Number plugin:

```groovy
job('example') {
  properties {
    nextBuildNumber(47)
  }
}
```

I added the `nextBuildNumber` method to the `properties` context because the Job DSL can't be extended within the `job` context directly.