### PR TITLE
fix: Prevent `NumberFormatException` on input

### DIFF
--- a/src/main/resources/org/jvnet/hudson/plugins/nextbuildnumber/NextBuildNumberAction/index.jelly
+++ b/src/main/resources/org/jvnet/hudson/plugins/nextbuildnumber/NextBuildNumberAction/index.jelly
@@ -22,13 +22,13 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form">
   <l:layout norefresh="true" xmlns:local="local">
     <st:include it="${it.job}" page="sidepanel.jelly" />
     <l:main-panel>
      <j:if test="${it.hasPermission(it.job)}">
       <form action="submit" method="post" name="nextbuildnumber">
-        ${%Next Build Number:} <input type="text" name="nextBuildNumber" value="${it.job.nextBuildNumber}"
+        ${%Next Build Number:} <input type="number" name="nextBuildNumber" value="${it.job.nextBuildNumber}"
                style="width:100%" id="nextBuildNumber" />
         <f:submit value="${%Submit}"/>
       </form>


### PR DESCRIPTION
By switching the input from `text` to `number`, we can prevent a NumberFormatException which is thrown, if the input is not a number but text.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did