### PR TITLE
Update parent POM, update dependencies, test with Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,11 @@
-#!/usr/bin/env groovy
-
-/* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin()
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
+buildPlugin(
+        forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
+        useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+        configurations: [
+                [platform: 'linux', jdk: 21],
+                [platform: 'windows', jdk: 17],
+        ])

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,6 @@
         <revision>1.9</revision>
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.361.4</jenkins.version>
-        <java.level>8</java.level>
     </properties>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,6 @@
     <packaging>hpi</packaging>
     <name>Next Build Number Plugin</name>
     <url>https://github.com/jenkinsci/next-build-number-plugin</url>
-    <description>Sets the build number Jenkins will use for a job's next build</description>
 
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -55,13 +55,12 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>job-dsl</artifactId>
-            <version>1.77</version>
+            <version>1.84</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>branch-api</artifactId>
-            <version>2.0.20.1</version>
         </dependency>
 
         <dependency>
@@ -75,7 +74,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.12</version>
             <type>jar</type>
             <optional>true</optional>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
-            <version>1.12</version>
+            <version>1.17</version>
             <type>jar</type>
             <optional>true</optional>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <revision>1.9</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.387.1</jenkins.version>
+        <jenkins.version>2.387.3</jenkins.version>
     </properties>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.25</version>
+        <version>4.74</version>
     </parent>
 
     <artifactId>next-build-number</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
@@ -22,7 +23,7 @@
     <properties>
         <revision>1.9</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.361.4</jenkins.version>
+        <jenkins.version>2.387.1</jenkins.version>
     </properties>
 
     <scm>
@@ -43,10 +44,10 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.361.x</artifactId>
-                <version>2102.v854b_fec19c92</version>
-                <type>pom</type>
+                <artifactId>bom-2.387.x</artifactId>
+                <version>2329.v078520e55c19</version>
                 <scope>import</scope>
+                <type>pom</type>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -86,13 +86,6 @@
             <scope>test</scope>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-test-harness-htmlunit</artifactId>
-            <version>154.v973ee207a_b_95</version>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 
     <!-- get every artifact through maven.glassfish.org, which proxies all the artifacts that we need -->

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1229.v4880b_b_e905a_6</version>
             <scope>test</scope>
             <optional>true</optional>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </properties>
 
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/next-build-number-plugin.git</connection>
+        <connection>scm:git:https://github.com/jenkinsci/next-build-number-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/next-build-number-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/next-build-number-plugin</url>
         <tag>${scmTag}</tag>
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1175.v4b_d517d6db_f0</version>
+            <version>1229.v4880b_b_e905a_6</version>
             <scope>test</scope>
             <optional>true</optional>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.56</version>
+            <version>1175.v4b_d517d6db_f0</version>
             <scope>test</scope>
             <optional>true</optional>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,12 @@
             <scope>test</scope>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.main</groupId>
+            <artifactId>jenkins-test-harness-htmlunit</artifactId>
+            <version>154.v973ee207a_b_95</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <revision>1.9</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.266</jenkins.version>
+        <jenkins.version>2.361.4</jenkins.version>
         <java.level>8</java.level>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,18 @@
         </developer>
     </developers>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.361.x</artifactId>
+                <version>2102.v854b_fec19c92</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<div>
+Sets the build number Jenkins will use for a job's next build
+</div>

--- a/src/test/java/org/jvnet/hudson/plugins/nextbuildnumber/JobTestBase.java
+++ b/src/test/java/org/jvnet/hudson/plugins/nextbuildnumber/JobTestBase.java
@@ -1,8 +1,8 @@
 package org.jvnet.hudson.plugins.nextbuildnumber;
 
-import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import hudson.model.Job;
 import hudson.security.AuthorizationStrategy;
+import org.htmlunit.html.HtmlForm;
 import org.junit.Before;
 import org.junit.Rule;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -21,7 +21,8 @@ public class JobTestBase {
 
     @SuppressWarnings("rawtypes")
     protected void performNextBuildNumberChange(Job project, String currenNumber, String changeToNumber) throws Exception {
-        HtmlForm form = jenkins.createWebClient().getPage(project, "nextbuildnumber").getFormByName("nextbuildnumber");
+        HtmlForm form;
+        form = jenkins.createWebClient().getPage(project, "nextbuildnumber").getFormByName("nextbuildnumber");
         assertEquals(currenNumber, form.getInputByName("nextBuildNumber").getDefaultValue());
         form.getInputByName("nextBuildNumber").setValueAttribute(changeToNumber);
         jenkins.submit(form);

--- a/src/test/java/org/jvnet/hudson/plugins/nextbuildnumber/JobTestBase.java
+++ b/src/test/java/org/jvnet/hudson/plugins/nextbuildnumber/JobTestBase.java
@@ -21,8 +21,7 @@ public class JobTestBase {
 
     @SuppressWarnings("rawtypes")
     protected void performNextBuildNumberChange(Job project, String currenNumber, String changeToNumber) throws Exception {
-        HtmlForm form;
-        form = jenkins.createWebClient().getPage(project, "nextbuildnumber").getFormByName("nextbuildnumber");
+        HtmlForm form = jenkins.createWebClient().getPage(project, "nextbuildnumber").getFormByName("nextbuildnumber");
         assertEquals(currenNumber, form.getInputByName("nextBuildNumber").getDefaultValue());
         form.getInputByName("nextBuildNumber").setValue(changeToNumber);
         jenkins.submit(form);

--- a/src/test/java/org/jvnet/hudson/plugins/nextbuildnumber/JobTestBase.java
+++ b/src/test/java/org/jvnet/hudson/plugins/nextbuildnumber/JobTestBase.java
@@ -24,7 +24,7 @@ public class JobTestBase {
         HtmlForm form;
         form = jenkins.createWebClient().getPage(project, "nextbuildnumber").getFormByName("nextbuildnumber");
         assertEquals(currenNumber, form.getInputByName("nextBuildNumber").getDefaultValue());
-        form.getInputByName("nextBuildNumber").setValueAttribute(changeToNumber);
+        form.getInputByName("nextBuildNumber").setValue(changeToNumber);
         jenkins.submit(form);
 
         form = jenkins.createWebClient().getPage(project, "nextbuildnumber").getFormByName("nextbuildnumber");


### PR DESCRIPTION
Java 21 was released Sep 19, 2023. We want to announce full support for Java 21 in early October and would like the most used plugins to be compiled and tested with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

The change intentionally tests only two Java configurations, Java 17 and Java 21 because we believe that the risk of a regression that only affects Java 11 is shallow. We generate Java 11 byte code with the Java 17 and the Java 21 builds, so we're already testing Java 11 byte code.

Testing done
===

Confirmed tests pass with Java 21 on Linux.

Supersedes pull request: #15.
Supersedes pull request: #17.
Supersedes pull request: #18.

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue