### PR TITLE
Require Jenkins 2.479.3 and Jakarta EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.86</version>
+        <version>5.10</version>
     </parent>
 
     <artifactId>next-build-number</artifactId>
@@ -22,8 +22,8 @@
 
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.baseline>2.452</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+        <jenkins.baseline>2.479</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     </properties>
 
     <scm>
@@ -45,7 +45,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>3944.v1a_e4f8b_452db_</version>
+                <version>4570.v1b_c718dd3b_1e</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/java/org/jvnet/hudson/plugins/nextbuildnumber/NextBuildNumberAction.java
+++ b/src/main/java/org/jvnet/hudson/plugins/nextbuildnumber/NextBuildNumberAction.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 
-import javax.servlet.ServletException;
+import jakarta.servlet.ServletException;
 
 import com.cloudbees.hudson.plugins.folder.computed.ComputedFolder;
 
@@ -39,8 +39,8 @@ import hudson.security.Permission;
 import jenkins.branch.MultiBranchProject;
 import jenkins.model.TransientActionFactory;
 import net.sf.json.JSONException;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
 /**
  *
@@ -108,7 +108,7 @@ public class NextBuildNumberAction implements Action {
         return Job.CONFIGURE;
     }
 
-    public synchronized void doSubmit( StaplerRequest req, StaplerResponse resp ) throws IOException, ServletException {
+    public synchronized void doSubmit( StaplerRequest2 req, StaplerResponse2 resp ) throws IOException, ServletException {
         checkPermission(job);
         try {
             int buildNumber = req.getSubmittedForm().getInt("nextBuildNumber");


### PR DESCRIPTION
## Require Jenkins 2.479.3 and Jakarta EE 9

Jenkins 2.479.3 provides Jakarta EE 9, Eclipse Jetty 12, Spring Security 6, and Java 17.

* Update plugin pom and baseline
* Remove deprecations
* Use Java 17 language features
* Minor cleanup

### Testing done

`mvn clean verify`

### Submitter checklist
* [x]  Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
* [x]  Ensure that the pull request title represents the desired changelog entry
* [x]  Please describe what you did
* [x]  Link to relevant issues in GitHub or Jira
* [x]  Link to relevant pull requests, esp. upstream and downstream changes
* [x]  Ensure you have provided tests - that demonstrates feature works or fixes the issue
